### PR TITLE
Add monoid imports to support even more old GHC versions

### DIFF
--- a/Data/Ascii/Blaze.hs
+++ b/Data/Ascii/Blaze.hs
@@ -5,6 +5,7 @@ module Data.Ascii.Blaze where
 import Data.Ascii.ByteString
 
 -- base
+import Data.Monoid (Monoid)
 import Data.Semigroup (Semigroup)
 
 -- blaze-builder

--- a/Data/Ascii/ByteString.hs
+++ b/Data/Ascii/ByteString.hs
@@ -7,6 +7,7 @@ import Data.Data (Data)
 import Data.Typeable (Typeable)
 import Data.String (IsString (..))
 import qualified Data.Char as C
+import Data.Monoid (Monoid)
 import Data.Semigroup (Semigroup)
 
 -- bytestring


### PR DESCRIPTION
With this change, ascii supports at least as far back as GHC 7.0
If you're not interested in supporting that far back, I'll make a PR to raise the base lower bound instead.

By the way, are you interested in Travis CI? There is a script I can run to give a good Travis setup to test whichever GHC versions you care about.