### PR TITLE
Use more accurate lower bound on `blaze-builder`

### DIFF
--- a/ascii.cabal
+++ b/ascii.cabal
@@ -33,7 +33,7 @@ Library
   Build-depends:       base             >= 4             && < 5
                      , bytestring       >= 0.9           && < 0.11
                      , text             >= 0.11          && < 1.3
-                     , blaze-builder    >= 0.2.1.4       && < 0.5
+                     , blaze-builder    >= 0.4           && < 0.5
                      , case-insensitive >= 0.2           && < 1.3
                      , hashable         >= 1.0           && < 1.3
                      , semigroups


### PR DESCRIPTION
As `ascii-0.0.5.*` relies on the `Semigroup` instance of `Builder` which isn't available for `blaze-builder < 0.4`:

```
Build profile: -w ghc-7.10.3 -O1
In order, the following will be built (use -v for more details):
 - ascii-0.0.5.2 (lib:ascii) (configuration changed)
Configuring ascii-0.0.5.2...
Preprocessing library for ascii-0.0.5.2..
Building library for ascii-0.0.5.2..
[3 of 4] Compiling Data.Ascii.Blaze ( Data/Ascii/Blaze.hs, /tmp/ascii-0.0.5.2/dist-newstyle/build/x86_64-linux/ghc-7.10.3/ascii-0.0.5.2/build/Data/Ascii/Blaze.o ) [Blaze.ByteString.Builder changed]

Data/Ascii/Blaze.hs:15:15:
    No instance for (Semigroup Blaze.Builder)
      arising from the 'deriving' clause of a data type declaration
    Possible fix:
      use a standalone 'deriving instance' declaration,
        so you can specify the instance context yourself
    When deriving the instance for (Semigroup AsciiBuilder)
```

I've already fixed up the metadata accordingly for the 3 affected releases:

 - https://hackage.haskell.org/package/ascii-0.0.5/revisions/
 - https://hackage.haskell.org/package/ascii-0.0.5.1/revisions/
 - https://hackage.haskell.org/package/ascii-0.0.5.2/revisions/
