### PR TITLE
Support GHC 9.4

### DIFF
--- a/ascii-case/ascii-case.cabal
+++ b/ascii-case/ascii-case.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-case
-version: 1.0.0.10
+version: 1.0.0.11
 x-revision: 1
 synopsis: ASCII letter case
 category: Data, Text
@@ -34,7 +34,7 @@ common base
 
     build-depends:
         ascii-char ^>= 1.0
-      , base >= 4.13 && < 4.17
+      , base >= 4.13 && < 4.18
 
 library
     import: base

--- a/ascii-char/ascii-char.cabal
+++ b/ascii-char/ascii-char.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-char
-version: 1.0.0.14
+version: 1.0.0.15
 synopsis: A Char type representing an ASCII character
 category: Data, Text
 
@@ -32,7 +32,7 @@ common base
         NoImplicitPrelude
 
     build-depends:
-        base >= 4.13 && < 4.17
+        base >= 4.13 && < 4.18
 
 library
     import: base

--- a/ascii-group/ascii-group.cabal
+++ b/ascii-group/ascii-group.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-group
-version: 1.0.0.12
+version: 1.0.0.13
 x-revision: 1
 synopsis: ASCII character groups
 category: Data, Text
@@ -35,7 +35,7 @@ common base
 
     build-depends:
         ascii-char ^>= 1.0
-      , base >= 4.13 && < 4.17
+      , base >= 4.13 && < 4.18
 
 library
     import: base

--- a/ascii-numbers/ascii-numbers.cabal
+++ b/ascii-numbers/ascii-numbers.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-numbers
-version: 1.1.0.0
+version: 1.1.0.1
 x-revision: 1
 synopsis: ASCII representations of numbers
 category: Data, Numeric, Text
@@ -44,10 +44,10 @@ common base
         ascii-case ^>= 1.0
       , ascii-char ^>= 1.0
       , ascii-superset ^>= 1.0.1
-      , base >= 4.13 && < 4.17
+      , base >= 4.13 && < 4.18
       , bytestring ^>= 0.10 || ^>= 0.11
       , hashable >= 1.3 && < 1.5
-      , text ^>= 1.2.4
+      , text >= 1.2.4 && < 2.1
 
 library
     import: base

--- a/ascii-predicates/ascii-predicates.cabal
+++ b/ascii-predicates/ascii-predicates.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-predicates
-version: 1.0.1.0
+version: 1.0.1.1
 x-revision: 1
 synopsis: Various categorizations of ASCII characters
 category: Data, Text
@@ -34,7 +34,7 @@ common base
 
     build-depends:
         ascii-char ^>= 1.0
-      , base >= 4.13 && < 4.17
+      , base >= 4.13 && < 4.18
 
 library
     import: base

--- a/ascii-superset/ascii-superset.cabal
+++ b/ascii-superset/ascii-superset.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-superset
-version: 1.0.1.13
+version: 1.0.1.14
 x-revision: 1
 synopsis: Representing ASCII with refined supersets
 category: Data, Text
@@ -39,8 +39,8 @@ common base
 
     build-depends:
         ascii-char ^>= 1.0
-      , base >= 4.13 && < 4.17
-      , text ^>= 1.2.4
+      , base >= 4.13 && < 4.18
+      , text >= 1.2.4 && < 2.1
 
 library
     import: base

--- a/ascii-th/ascii-th.cabal
+++ b/ascii-th/ascii-th.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii-th
-version: 1.0.0.10
+version: 1.0.0.11
 x-revision: 1
 synopsis: Template Haskell support for ASCII
 category: Data, Text
@@ -38,14 +38,14 @@ common base
     build-depends:
         ascii-char ^>= 1.0
       , ascii-superset ^>= 1.0
-      , base >= 4.13 && < 4.17
+      , base >= 4.13 && < 4.18
 
 library
     import: base
     hs-source-dirs: library
 
     build-depends:
-        template-haskell >= 2.15 && < 2.19
+        template-haskell >= 2.15 && < 2.20
 
     exposed-modules:
         ASCII.TemplateHaskell

--- a/ascii/ascii.cabal
+++ b/ascii/ascii.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: ascii
-version: 1.2.3.0
+version: 1.2.3.1
 x-revision: 1
 synopsis: The ASCII character set and encoding
 category: Data, Text
@@ -32,8 +32,8 @@ common base
         NoImplicitPrelude
 
     build-depends:
-        base >= 4.13 && < 4.17
-      , text ^>= 1.2.4
+        base >= 4.13 && < 4.18
+      , text >= 1.2.4 && < 2.1
 
 library
     import: base


### PR DESCRIPTION
Looks like things build and tests pass just bumping the versions.

Changes to the dependencies of `text` on `ghc-prim` mean we need to increase the upper bound on `text` to `2.1`, but looks like whatever changes `text` made to justify that bump, didn't affect ASCII. (At least, the tests still pass.)

Fixes #15.